### PR TITLE
Change UBOre to prevent resources dropping when tools have a less tha…

### DIFF
--- a/src/main/java/exterminatorjeff/undergroundbiomes/common/block/UBOre.java
+++ b/src/main/java/exterminatorjeff/undergroundbiomes/common/block/UBOre.java
@@ -230,7 +230,8 @@ public abstract class UBOre extends Block implements UBSubBlock {
 
   @Override
   public boolean canHarvestBlock(IBlockAccess world, BlockPos pos, EntityPlayer player) {
-    return player.getHeldItemMainhand().canHarvestBlock(baseOreState);
+    //return player.getHeldItemMainhand().canHarvestBlock(baseOreState);
+    return super.canHarvestBlock(world, pos, player); // Change restores behaviour where tools with lower harvest levels do not provide resources
   }
 
   @Override


### PR DESCRIPTION
…n required harvest level.

This fixes a bug where tools with lower than required harvest levels would continue to drop the blocks resources.

Essentially the harvest level calc was being delegated to the tool which generally (as by vanilla standards) doesn't query the hardness level for MATERIAL.rock. This uses the established forge mechanisms for preventing this undesirable behaviour.

Fixes: #200 #62