### PR TITLE
Fix cascading world gen lag

### DIFF
--- a/src/main/java/exterminatorjeff/undergroundbiomes/world/UBStoneReplacer.java
+++ b/src/main/java/exterminatorjeff/undergroundbiomes/world/UBStoneReplacer.java
@@ -266,7 +266,9 @@ public abstract class UBStoneReplacer implements UBStrataColumnProvider {
     HashMap<ChunkPos, ArrayList<BlockPos>> toRedo = OresRegistry.INSTANCE.forRedo(world);
     for (ChunkPos chunkID : toRedo.keySet()) {
       ArrayList<BlockPos> locations = toRedo.get(chunkID);
-      Chunk chunk = world.getChunk(chunkID.x, chunkID.z);
+      Chunk chunk = world.getChunkProvider().getLoadedChunk(chunkID.x, chunkID.z);
+      if (chunk == null)
+        continue;
       int[] biomeValues = getBiomeValues(chunk);
       for (BlockPos location : locations) {
         IBlockState currentBlockState = chunk.getBlockState(location);


### PR DESCRIPTION
Stacktrace:

```
[java.lang.Thread:dumpStack:1336]: java.lang.Exception: Stack trace
[java.lang.Thread:dumpStack:1336]: at java.lang.Thread.dumpStack(Thread.java:1336)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.world.chunk.Chunk.handler$zzk004$onInit(Chunk.java:2823)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.world.chunk.Chunk.logCascadingWorldGeneration(Chunk.java)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.world.chunk.Chunk.func_186034_a(Chunk.java:1006)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.world.chunk.Chunk.func_186030_a(Chunk.java:985)
[java.lang.Thread:dumpStack:1336]: at net.minecraftforge.common.chunkio.ChunkIOProvider.syncCallback(ChunkIOProvider.java:110)
[java.lang.Thread:dumpStack:1336]: at net.minecraftforge.common.chunkio.ChunkIOExecutor.syncChunkLoad(ChunkIOExecutor.java:94)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.world.gen.ChunkProviderServer.loadChunk(ChunkProviderServer.java:118)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.world.gen.ChunkProviderServer.func_186028_c(ChunkProviderServer.java:89)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.world.gen.ChunkProviderServer.bridge$loadChunkForce(ChunkProviderServer.java:2098)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.world.gen.ChunkProviderServer.redirect$znm000$impl$ProvideChunkForced(ChunkProviderServer.java:1651)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.world.gen.ChunkProviderServer.func_186025_d(ChunkProviderServer.java:135)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.world.World.func_72964_e(World.java:310)
[java.lang.Thread:dumpStack:1336]: at exterminatorjeff.undergroundbiomes.world.UBStoneReplacer.redoOres(UBStoneReplacer.java:259)
[java.lang.Thread:dumpStack:1336]: at exterminatorjeff.undergroundbiomes.world.WorldGenManager.onPopulateChunkPost(WorldGenManager.java:89)
[java.lang.Thread:dumpStack:1336]: at exterminatorjeff.undergroundbiomes.core.DimensionManager.onPopulateChunkPost(DimensionManager.java:107)
[java.lang.Thread:dumpStack:1336]: at net.minecraftforge.fml.common.eventhandler.ASMEventHandler_649_DimensionManager_onPopulateChunkPost_Post.invoke(.dynamic)
[java.lang.Thread:dumpStack:1336]: at net.minecraftforge.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:90)
[java.lang.Thread:dumpStack:1336]: at net.minecraftforge.fml.common.eventhandler.EventBus.forgeBridge$post(EventBus.java:753)
[java.lang.Thread:dumpStack:1336]: at net.minecraftforge.fml.common.eventhandler.EventBus.post(EventBus.java:703)
[java.lang.Thread:dumpStack:1336]: at org.spongepowered.mod.world.gen.SpongeChunkGeneratorForge.func_185931_b(SpongeChunkGeneratorForge.java:291)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.world.chunk.Chunk.func_186034_a(Chunk.java:1019)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.world.chunk.Chunk.func_186030_a(Chunk.java:985)
[java.lang.Thread:dumpStack:1336]: at net.minecraftforge.common.chunkio.ChunkIOProvider.syncCallback(ChunkIOProvider.java:110)
[java.lang.Thread:dumpStack:1336]: at net.minecraftforge.common.chunkio.ChunkIOExecutor.tick(ChunkIOExecutor.java:150)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:728)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:397)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:668)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:526)
[java.lang.Thread:dumpStack:1336]: at java.lang.Thread.run(Thread.java:748)
```